### PR TITLE
Capitalize keywords when used as the fallback title

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,6 +128,11 @@ const element = (tagName, classes = [], children = []) => {
   };
 };
 
+// changes the first character of a keyword to uppercase so that custom title
+// styles may omit `text-transform: uppercase`.
+const formatKeyword = keyword =>
+  keyword.charAt(0).toUpperCase() + keyword.slice(1);
+
 // passed to unified.use()
 // you have to use a named function for access to `this` :(
 module.exports = function attacher(options) {
@@ -181,7 +186,10 @@ module.exports = function attacher(options) {
     );
     exit();
     // parse the title in inline mode
-    const titleNodes = this.tokenizeInline(title || keyword, now);
+    const titleNodes = this.tokenizeInline(
+      title || formatKeyword(keyword),
+      now
+    );
     // create the nodes for the icon
     const entry = config.types[keyword];
     const settings = typeof entry === "string" ? config.types[entry] : entry;

--- a/test/emoji.ref
+++ b/test/emoji.ref
@@ -9,7 +9,7 @@
     <h1>This is a test</h1>
     <div class="admonition admonition-note alert alert--secondary">
       <div class="admonition-heading">
-        <h5><span class="admonition-icon">ℹ️</span>note</h5>
+        <h5><span class="admonition-icon">ℹ️</span>Note</h5>
       </div>
       <div class="admonition-content">
         <p>This is what a note looks like</p>
@@ -17,7 +17,7 @@
     </div>
     <div class="admonition admonition-tip alert alert--success">
       <div class="admonition-heading">
-        <h5><span class="admonition-icon">💡</span>tip</h5>
+        <h5><span class="admonition-icon">💡</span>Tip</h5>
       </div>
       <div class="admonition-content">
         <p>It works great with docusaurus 2.0</p>
@@ -42,7 +42,7 @@
     </div>
     <div class="admonition admonition-warning alert alert--danger">
       <div class="admonition-heading">
-        <h5><span class="admonition-icon">🔥</span>warning</h5>
+        <h5><span class="admonition-icon">🔥</span>Warning</h5>
       </div>
       <div class="admonition-content">
         <p>You can't nest them</p>
@@ -60,7 +60,7 @@
     </div>
     <div class="admonition admonition-custom">
       <div class="admonition-heading">
-        <h5><span class="admonition-icon">💻</span>custom</h5>
+        <h5><span class="admonition-icon">💻</span>Custom</h5>
       </div>
       <div class="admonition-content">
         <p>You can make your own custom types. The icon, keyword, and emoji can be set in the plugin options and they can be styled separately.</p>

--- a/test/none.ref
+++ b/test/none.ref
@@ -9,7 +9,7 @@
     <h1>This is a test</h1>
     <div class="admonition admonition-note alert alert--secondary">
       <div class="admonition-heading">
-        <h5>note</h5>
+        <h5>Note</h5>
       </div>
       <div class="admonition-content">
         <p>This is what a note looks like</p>
@@ -17,7 +17,7 @@
     </div>
     <div class="admonition admonition-tip alert alert--success">
       <div class="admonition-heading">
-        <h5>tip</h5>
+        <h5>Tip</h5>
       </div>
       <div class="admonition-content">
         <p>It works great with docusaurus 2.0</p>
@@ -42,7 +42,7 @@
     </div>
     <div class="admonition admonition-warning alert alert--danger">
       <div class="admonition-heading">
-        <h5>warning</h5>
+        <h5>Warning</h5>
       </div>
       <div class="admonition-content">
         <p>You can't nest them</p>
@@ -60,7 +60,7 @@
     </div>
     <div class="admonition admonition-custom">
       <div class="admonition-heading">
-        <h5>custom</h5>
+        <h5>Custom</h5>
       </div>
       <div class="admonition-content">
         <p>You can make your own custom types. The icon, keyword, and emoji can be set in the plugin options and they can be styled separately.</p>

--- a/test/svg.ref
+++ b/test/svg.ref
@@ -11,7 +11,7 @@
       <div class="admonition-heading">
         <h5><span class="admonition-icon"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16">
               <path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path>
-            </svg></span>note</h5>
+            </svg></span>Note</h5>
       </div>
       <div class="admonition-content">
         <p>This is what a note looks like</p>
@@ -21,7 +21,7 @@
       <div class="admonition-heading">
         <h5><span class="admonition-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16">
               <path fill-rule="evenodd" d="M6.5 0C3.48 0 1 2.19 1 5c0 .92.55 2.25 1 3 1.34 2.25 1.78 2.78 2 4v1h5v-1c.22-1.22.66-1.75 2-4 .45-.75 1-2.08 1-3 0-2.81-2.48-5-5.5-5zm3.64 7.48c-.25.44-.47.8-.67 1.11-.86 1.41-1.25 2.06-1.45 3.23-.02.05-.02.11-.02.17H5c0-.06 0-.13-.02-.17-.2-1.17-.59-1.83-1.45-3.23-.2-.31-.42-.67-.67-1.11C2.44 6.78 2 5.65 2 5c0-2.2 2.02-4 4.5-4 1.22 0 2.36.42 3.22 1.19C10.55 2.94 11 3.94 11 5c0 .66-.44 1.78-.86 2.48zM4 14h5c-.23 1.14-1.3 2-2.5 2s-2.27-.86-2.5-2z"></path>
-            </svg></span>tip</h5>
+            </svg></span>Tip</h5>
       </div>
       <div class="admonition-content">
         <p>It works great with docusaurus 2.0</p>
@@ -52,7 +52,7 @@
       <div class="admonition-heading">
         <h5><span class="admonition-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16">
               <path fill-rule="evenodd" d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"></path>
-            </svg></span>warning</h5>
+            </svg></span>Warning</h5>
       </div>
       <div class="admonition-content">
         <p>You can't nest them</p>
@@ -72,7 +72,7 @@
       <div class="admonition-heading">
         <h5><span class="admonition-icon"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
               <path fill-rule="evenodd" d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"></path>
-            </svg></span>custom</h5>
+            </svg></span>Custom</h5>
       </div>
       <div class="admonition-content">
         <p>You can make your own custom types. The icon, keyword, and emoji can be set in the plugin options and they can be styled separately.</p>


### PR DESCRIPTION
Currently when an admonition is used without a custom title, the keyword is used as the title. Keywords are all lowercase, and as such use `text-transform: uppercase`.

In my own use of Docusaurus, I'm customising the styles and prefer to use `text-transform: none`. This is fine as long as a custom title is used, but results in this when falling back to the keyword:

![Screenshot 2020-04-28 at 18 04 23](https://user-images.githubusercontent.com/4383/80516093-dc1b1800-897a-11ea-9b4f-f02a8454d73e.png)

It's possible to use `text-transform: capitalize` to work around this, but it isn't a perfect solution as it results in capitalization even when it isn't desired:

![Screenshot 2020-04-28 at 18 08 01](https://user-images.githubusercontent.com/4383/80516418-55b30600-897b-11ea-9b3b-28480ee92bef.png)

This PR capitalizes the first letter of the keyword when used as the admonition title, allowing other `text-transform` values to be applied. It should have no effect on the default styles.

![Screenshot 2020-04-28 at 19 16 55](https://user-images.githubusercontent.com/4383/80522687-e04c3300-8984-11ea-8bfa-ada15b07ca7e.png)