### PR TITLE
feat: support empty admonition titles via config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ unified()
 
 `@docusaurus/preset-classic` includes `remark-admonitions`.
 
-If you aren't using `@docusaurus/preset-classic`, `remark-admonitions` can still be used through passing a `remark` plugin to MDX. 
+If you aren't using `@docusaurus/preset-classic`, `remark-admonitions` can still be used through passing a `remark` plugin to MDX.
 # Usage
 
-Admonitions are a block element. 
+Admonitions are a block element.
 The titles can include inline markdown and the body can include any block markdown except another admonition.
 
 The general syntax is
@@ -94,12 +94,13 @@ const options = {
   tag: string, // the tag to be used for creating admonitions (default ":::")
   icons: "svg"|"emoji"|"none", // the type of icons to use (default "svg")
   infima: boolean, // wether the classes for infima alerts should be added to the markup
+  useKeywordAsTitle: boolean, // whether keyword is used as default title if title was not provided (default true)
 }
 ```
 
 ## Custom Types
 
-The `customTypes` option can be used to add additional types of admonitions. You can set the svg and emoji icons as well as the keyword. You only have to include the svg/emoji fields if you are using them. 
+The `customTypes` option can be used to add additional types of admonitions. You can set the svg and emoji icons as well as the keyword. You only have to include the svg/emoji fields if you are using them.
 The ifmClass is only necessary if the `infima` setting is `true` and the admonition should use the look of an existing Infima alert class.
 
 ```ts
@@ -138,7 +139,7 @@ If the `infima` option is `true`, the classes `alert alert--{type}` will be adde
 
 # Styling
 
-You'll have to add styles for the admonitions. With Docusaurus, these can be added to `custom.css`. 
+You'll have to add styles for the admonitions. With Docusaurus, these can be added to `custom.css`.
 
 ## Infima (Docusaurus v2)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -210,10 +210,10 @@ module.exports = function attacher(options) {
       ),
       headingNodes.length
         ? [
-            element("div", "admonition-heading", [element("h5", "")]),
+            element("div", "admonition-heading", [element("h5", "", headingNodes)]),
             contentNodes
           ]
-        : []
+        : [contentNodes]
     );
 
     return add(admonition);

--- a/lib/index.js
+++ b/lib/index.js
@@ -210,7 +210,9 @@ module.exports = function attacher(options) {
       ),
       headingNodes.length
         ? [
-            element("div", "admonition-heading", [element("h5", "", headingNodes)]),
+            element("div", "admonition-heading", [
+              element("h5", "", headingNodes)
+            ]),
             contentNodes
           ]
         : [contentNodes]

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ const types = {
 const defaultOptions = {
   customTypes: [],
   useDefaultTypes: true,
+  useKeywordAsTitle: true,
   infima: true,
   tag: ":::",
   icons: "svg"
@@ -186,10 +187,10 @@ module.exports = function attacher(options) {
     );
     exit();
     // parse the title in inline mode
-    const titleNodes = this.tokenizeInline(
-      title || formatKeyword(keyword),
-      now
-    );
+    const titleNodes =
+      title || config.useKeywordAsTitle
+        ? this.tokenizeInline(title || formatKeyword(keyword), now)
+        : [];
     // create the nodes for the icon
     const entry = config.types[keyword];
     const settings = typeof entry === "string" ? config.types[entry] : entry;
@@ -200,18 +201,19 @@ module.exports = function attacher(options) {
         ? []
         : [element("span", "admonition-icon", [iconNodes])];
 
+    const headingNodes = iconContainerNodes.concat(titleNodes);
     // build the nodes for the full markup
     const admonition = element(
       "div",
       ["admonition", `admonition-${keyword}`].concat(
         settings.ifmClass ? ["alert", `alert--${settings.ifmClass}`] : []
       ),
-      [
-        element("div", "admonition-heading", [
-          element("h5", "", iconContainerNodes.concat(titleNodes))
-        ]),
-        contentNodes
-      ]
+      headingNodes.length
+        ? [
+            element("div", "admonition-heading", [element("h5", "")]),
+            contentNodes
+          ]
+        : []
     );
 
     return add(admonition);


### PR DESCRIPTION
Support a new config option to allow admonitions without a title.

On the screenshot, there are two admonitions without title, with the default Infima theme, and one more with slightly modified one.

![image](https://user-images.githubusercontent.com/3975738/114357900-f42f7b80-9b7a-11eb-968b-a13a0ab958ba.png)
